### PR TITLE
Build Fix for Tizen 6.0

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -22,7 +22,7 @@ list(GET roscpp_VERSION_LIST 2 roscpp_VERSION_PATCH)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ros/common.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros/common.h)
 
-find_package(Boost REQUIRED COMPONENTS signals filesystem system)
+find_package(Boost REQUIRED COMPONENTS filesystem system)
 
 include_directories(include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -229,7 +229,7 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
     {
       if (!timeout.isZero())
       {
-        condition_.timed_wait(lock, boost::posix_time::microseconds(timeout.toSec() * 1000000.0f));
+        condition_.timed_wait(lock, boost::posix_time::microseconds(long(timeout.toSec() * 1000000.0f)));
       }
 
       if (callbacks_.empty())
@@ -305,7 +305,7 @@ void CallbackQueue::callAvailable(ros::WallDuration timeout)
     {
       if (!timeout.isZero())
       {
-        condition_.timed_wait(lock, boost::posix_time::microseconds(timeout.toSec() * 1000000.0f));
+        condition_.timed_wait(lock, boost::posix_time::microseconds(long(timeout.toSec() * 1000000.0f)));
       }
 
       if (callbacks_.empty() || !enabled_)

--- a/test/test_roscpp/CMakeLists.txt
+++ b/test/test_roscpp/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(Boost REQUIRED COMPONENTS signals filesystem system)
+  find_package(Boost REQUIRED COMPONENTS filesystem system)
 
   include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/utilities/message_filters/CMakeLists.txt
+++ b/utilities/message_filters/CMakeLists.txt
@@ -13,7 +13,7 @@ catkin_package(
 )
 catkin_python_setup()
 
-find_package(Boost REQUIRED COMPONENTS signals thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
There are two commits to follow up with Tizen 6.0, which are tested at build.tizen.org:


commit b2c69c30c5ba33211ae57e1cd0975addd210cbcc (HEAD -> tizen6fix, origin/tizen6fix)
Author: MyungJoo Ham <myungjoo.ham@samsung.com>
Date:   Wed May 13 13:58:08 2020 +0900

    [Tizen6 Fix] Strict type checking
    
    Don't feed float to long argument.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

commit 5fb913da7e3d673470b50b325e6103c7e2589214 (tizen6/fix, tizen)
Author: Maarten de Vries <maarten@de-vri.es>
Date:   Thu Jan 31 00:58:29 2019 +0100

    Remove signals from find_package(Boost COMPONENTS ...) (#1580)
    
    The packages use signals2, not signals. Only boost libraries with
    compiled code should be passed to find_package(Boost COMPONENTS ...),
    and the signals2 library has always been header only.
    
    Boost 1.69 has removed the deprecated signals library, so the otherwise
    useless but harmless `signals` component now breaks the build.
    
    Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
